### PR TITLE
Install color-theme-modern

### DIFF
--- a/init.el
+++ b/init.el
@@ -22,6 +22,7 @@
     auto-highlight-symbol
     coffee-mode
     color-moccur
+    color-theme-modern
     company
     company-go
     dockerfile-mode

--- a/inits/40-color-theme.el
+++ b/inits/40-color-theme.el
@@ -1,7 +1,5 @@
 ;; Color theme
 (cond ((not (null window-system))
-       (add-to-list 'custom-theme-load-path
-                    (file-name-as-directory "~/.emacs.d/el-get/replace-colorthemes/"))
        (load-theme 'dark-laptop t t)
        (enable-theme 'dark-laptop)
        ))


### PR DESCRIPTION
[emacs-jp/replace-colorthemes](https://github.com/emacs-jp/replace-colorthemes) can be installed from MELPA as `color-theme-modern`.