### PR TITLE
Re-enable git-gutter

### DIFF
--- a/init.el
+++ b/init.el
@@ -35,7 +35,7 @@
     flymake
     flymake-coffee
     flymake-cursor
-    ;; git-gutter
+    git-gutter
     gnuplot-mode
     go-eldoc
     go-mode

--- a/inits/50-git-gutter.el
+++ b/inits/50-git-gutter.el
@@ -1,6 +1,8 @@
-;; (global-git-gutter-mode t)
-;; (git-gutter:linum-setup)
+;; ref: Compatible issue with linum-mode in Emacs 26.1
+;; https://github.com/syohex/emacs-git-gutter/issues/156
 
-;; ;; live update (1 second interval)
-;; (custom-set-variables
-;;  '(git-gutter:update-interval 1))
+(global-git-gutter-mode t)
+
+;; Emacs 25 or lower uses linum-mode
+(if (version< emacs-version "26.0")
+    (git-gutter:linum-setup))


### PR DESCRIPTION
Now git-gutter works well with display-numbers-mode in Emacs 26.