### PR TITLE
Update test target Emacses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 env:
   - EMACS_VERSION=25.1
   - EMACS_VERSION=25.2
+  - EMACS_VERSION=26.1
 before_install:
   - make symlink
   # Configure $PATH: Executables are installed to $HOME/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: emacs-lisp
 # https://github.com/travis-ci/travis-ci/issues/9073#issuecomment-358701996
 sudo: required
 env:
-  - EMACS_VERSION=25.1
-  - EMACS_VERSION=25.2
+  - EMACS_VERSION=25.3
   - EMACS_VERSION=26.1
 before_install:
   - make symlink


### PR DESCRIPTION
## WHAT

Use the latest Emacs 25.x and 26.x

## WHY

Now I'm using Emacs 26.1 in my computers. Therefore this repository should be tested against Emacs 26.