### PR TITLE
Introduce use-package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ recentf
 
 /.cask
 /games
+
+/transient

--- a/init.el
+++ b/init.el
@@ -50,7 +50,6 @@
     highlight-symbol
     htmlize
     indent-guide
-    init-loader
     json-mode
     less-css-mode
     magit
@@ -104,8 +103,9 @@
   (setq exec-path-from-shell-check-startup-files nil)
   (exec-path-from-shell-copy-envs envs))
 
-(require 'init-loader)
-;; http://d.hatena.ne.jp/syohex/20140706/1404637327
-(custom-set-variables
- '(init-loader-show-log-after-init 'error-only))
-(init-loader-load (concat user-emacs-directory "inits"))
+(use-package init-loader
+  :ensure t
+  :init
+  (setq init-loader-show-log-after-init 'error-only)
+  :config
+  (init-loader-load (concat user-emacs-directory "inits")))

--- a/init.el
+++ b/init.el
@@ -27,7 +27,6 @@
     company-go
     dockerfile-mode
     enh-ruby-mode
-    exec-path-from-shell
     expand-region
     feature-mode
     flycheck
@@ -98,10 +97,13 @@
   (load custom-file))
 
 ;; Enable environment variables for all package installations
-(let ((envs '("PATH" "GOPATH" "GOROOT")))
-  (exec-path-from-shell-initialize)
-  (setq exec-path-from-shell-check-startup-files nil)
-  (exec-path-from-shell-copy-envs envs))
+(use-package exec-path-from-shell
+  :ensure t
+  :config
+  (let ((envs '("PATH" "GOPATH" "GOROOT")))
+    (exec-path-from-shell-initialize)
+    (setq exec-path-from-shell-check-startup-files nil)
+    (exec-path-from-shell-copy-envs envs)))
 
 (use-package init-loader
   :ensure t

--- a/init.el
+++ b/init.el
@@ -87,6 +87,13 @@
   (unless (package-installed-p pkg)
     (package-install pkg)))
 
+;; ensure to use use-package
+(unless package-archive-contents
+  (package-refresh-contents))
+(when (not (package-installed-p 'use-package))
+  (package-install 'use-package))
+(require 'use-package)
+
 (setq custom-file (expand-file-name "custom.el" user-emacs-directory))
 (when (file-exists-p custom-file)
   (load custom-file))


### PR DESCRIPTION
- Install use-package if it's not installed
- Use exec-path-from-shell and init-loader via use-package
  - At first, I migrated them in `init.el`

[jwiegley/use-package: A use-package declaration for simplifying your .emacs](https://github.com/jwiegley/use-package)

> The use-package macro allows you to isolate package configuration in your .emacs file in a way that is both performance-oriented and, well, tidy

### `emacs-init-time`

- before: 4.5 seconds
- after: 4.4 seconds