### PR TITLE
Use highlight-indent-guides instead of indent-guide

### DIFF
--- a/inits/40-highlight-indent-guides.el
+++ b/inits/40-highlight-indent-guides.el
@@ -1,0 +1,8 @@
+(use-package highlight-indent-guides
+  :ensure t
+  :hook (yaml-mode . highlight-indent-guides-mode)
+  :custom
+  (highlight-indent-guides-character ?\|)
+  (highlight-indent-guides-auto-enabled t)
+  (highlight-indent-guides-responsive t)
+  (highlight-indent-guides-method 'character))

--- a/inits/40-indent-guide.el
+++ b/inits/40-indent-guide.el
@@ -1,5 +1,0 @@
-(use-package indent-guide
-  :ensure t
-  :config
-  (setq indent-guide-delay 0.1)
-  (setq indent-guide-recursive t))


### PR DESCRIPTION
Use [highlight-indent-guides](https://github.com/DarthFennec/highlight-indent-guides) instead of [indent-guide](https://github.com/zk-phi/indent-guide)

![image](https://user-images.githubusercontent.com/680124/54087189-e0116280-4393-11e9-8aa6-626ed79d55a9.png)
